### PR TITLE
Phase2 video report fetcher gen2

### DIFF
--- a/src/common_requirements.txt
+++ b/src/common_requirements.txt
@@ -1,6 +1,7 @@
 functions-framework==3.10.2
-google-auth==2.56.2
+google-auth==2.56.3
 google-api-python-client==2.198.0
-google-cloud-logging==3.16.1
-google-cloud-pubsub==2.39.0
+google-cloud-logging==3.16.2
+google-cloud-pubsub==2.39.1
+google-cloud-bigquery==3.43.0
 jsonschema==4.26.0

--- a/src/gads_account_dispatcher/main.py
+++ b/src/gads_account_dispatcher/main.py
@@ -15,7 +15,7 @@
 """Fetch the Google Ads configs and push them to pub/sub."""
 
 import os
-from typing import Any
+from typing import Any, Optional
 
 import flask
 import functions_framework
@@ -24,6 +24,7 @@ from googleapiclient import discovery
 import jsonschema
 from vet_common.ids import sanitize_gads_id
 from vet_common.logging import get_service_logger
+from vet_common.logging import PipelineTelemetryContext
 from vet_common.pubsub import publish_batch
 
 logger = get_service_logger()
@@ -47,11 +48,15 @@ REQUEST_SCHEMA = {
 }
 
 
-def _get_config_from_sheet(sheet_id: str) -> list[dict[str, Any]]:
+def _get_config_from_sheet(
+    sheet_id: str,
+    telemetry: Optional[PipelineTelemetryContext] = None,
+) -> list[dict[str, Any]]:
   """Gets the Ads account config from the Google Sheet, and return the results.
 
   Args:
       sheet_id: The ID of the Google Sheet containing the config.
+      telemetry: Optional telemetry context for tracking step metrics.
 
   Returns:
       A row for each account a report needs to be run for.
@@ -71,6 +76,10 @@ def _get_config_from_sheet(sheet_id: str) -> list[dict[str, Any]]:
           ...
       ]
   """
+  telemetry = telemetry or PipelineTelemetryContext(
+      logger=logger,
+      service_name=os.environ.get('K_SERVICE', 'vet-gads-account-dispatcher'),
+  )
   logger.info('Getting config from sheet: %s', sheet_id)
   credentials, _ = google.auth.default(scopes=SCOPES)
   sheets_service = discovery.build(
@@ -135,6 +144,18 @@ def _get_config_from_sheet(sheet_id: str) -> list[dict[str, Any]]:
 
   logger.info('Account configs:')
   logger.info(account_configs)
+
+  telemetry.log_step(
+      step='FETCH_CONFIG_SHEET',
+      records_in=len(customer_ids),
+      records_out=len(account_configs),
+      metadata={
+          'sheet_id': sheet_id,
+          'enabled_count': len(account_configs),
+          'disabled_count': len(customer_ids) - len(account_configs),
+      },
+  )
+
   return account_configs
 
 
@@ -162,19 +183,44 @@ def _gads_filters_to_gaql_string(config_filters: list[list[str]]) -> str:
   return ' AND '.join(conditions)
 
 
-def run(sheet_id: str) -> None:
+def run(
+    sheet_id: str,
+    telemetry: Optional[PipelineTelemetryContext] = None,
+) -> None:
   """Orchestration for the function.
 
   Args:
       sheet_id: the ID of the Google Sheet containing the config.
+      telemetry: Optional telemetry context for tracking step metrics.
   """
+  telemetry = telemetry or PipelineTelemetryContext(
+      logger=logger,
+      service_name=os.environ.get('K_SERVICE', 'vet-gads-account-dispatcher'),
+  )
   logger.info('Running Google Ads account script')
+  configs = _get_config_from_sheet(sheet_id=sheet_id, telemetry=telemetry)
   publish_batch(
       project_id=GOOGLE_CLOUD_PROJECT,
       topic_id=ACCOUNT_PUBSUB_TOPIC,
-      messages=_get_config_from_sheet(sheet_id),
+      messages=configs,
       logger=logger,
   )
+
+  telemetry.log_step(
+      step='DISPATCH_PUBSUB',
+      records_in=len(configs),
+      records_out=len(configs),
+      metadata={
+          'topic': ACCOUNT_PUBSUB_TOPIC,
+          'dispatched_count': len(configs),
+      },
+  )
+  telemetry.log_step(
+      step='COMPLETE',
+      records_out=len(configs),
+      metadata={'status': 'Success'},
+  )
+
   logger.info('Done.')
 
 
@@ -191,6 +237,10 @@ def main(request: flask.Request) -> flask.Response:
       The flask response.
   """
   logger.info('Google Ads Account dispatch triggered.')
+  telemetry = PipelineTelemetryContext(
+      logger=logger,
+      service_name=os.environ.get('K_SERVICE', 'vet-gads-account-dispatcher'),
+  )
 
   request_json = request.get_json(silent=True)
   logger.info('JSON payload: %s', request_json)
@@ -199,16 +249,34 @@ def main(request: flask.Request) -> flask.Response:
     jsonschema.validate(instance=request_json, schema=REQUEST_SCHEMA)
   except jsonschema.exceptions.ValidationError as err:
     logger.error('Invalid request payload: %s', err)
+    telemetry.log_step(
+        step='INITIALIZE',
+        status='FAILED',
+        error=err,
+    )
     response['status'] = 'Failed'
     response['message'] = err.message
     return flask.Response(
         flask.json.dumps(response), status=400, mimetype='application/json'
     )
 
+  sheet_id = request_json['sheet_id']
+  telemetry.log_step(
+      step='INITIALIZE',
+      status='SUCCESS',
+      metadata={'sheet_id': sheet_id},
+  )
+
   try:
-    run(request_json['sheet_id'])
+    run(sheet_id=sheet_id, telemetry=telemetry)
   except Exception as err:  # pylint: disable=broad-except
     logger.error('Failed to run Google Ads account script: %s', err)
+    telemetry.log_step(
+        step='ERROR',
+        status='FAILED',
+        error=err,
+        metadata={'sheet_id': sheet_id},
+    )
     response['status'] = 'Failed'
     response['message'] = str(err)
     return flask.Response(

--- a/src/gads_account_dispatcher/tests/test_dispatcher_main.py
+++ b/src/gads_account_dispatcher/tests/test_dispatcher_main.py
@@ -91,7 +91,10 @@ def test_get_config_from_sheet_valid_sheet_returns_customer_configs(
 
   mock_spreadsheets.values.return_value.get.side_effect = values_get_side_effect
 
-  result = main._get_config_from_sheet('test_sheet_123')
+  mock_telemetry = mock.Mock()
+  result = main._get_config_from_sheet(
+      'test_sheet_123', telemetry=mock_telemetry
+  )
 
   assert len(result) == 2
   assert result[0] == {
@@ -110,6 +113,16 @@ def test_get_config_from_sheet_valid_sheet_returns_customer_configs(
       'gads_filters': expected_gads_filters,
       'settings': expected_settings,
   }
+  mock_telemetry.log_step.assert_called_once_with(
+      step='FETCH_CONFIG_SHEET',
+      records_in=4,
+      records_out=2,
+      metadata={
+          'sheet_id': 'test_sheet_123',
+          'enabled_count': 2,
+          'disabled_count': 2,
+      },
+  )
 
 
 @mock.patch.object(main.discovery, 'build')
@@ -159,9 +172,13 @@ def test_run_valid_sheet_fetches_config_and_publishes_batch(
     mock_get_config, mock_publish
 ):
   mock_get_config.return_value = [{'sheet_id': 's1'}]
-  main.run('test_sheet_123')
-  mock_get_config.assert_called_once_with('test_sheet_123')
+  mock_telemetry = mock.Mock()
+  main.run('test_sheet_123', telemetry=mock_telemetry)
+  mock_get_config.assert_called_once_with(
+      sheet_id='test_sheet_123', telemetry=mock_telemetry
+  )
   mock_publish.assert_called_once()
+  assert mock_telemetry.log_step.call_count == 2
 
 
 def test_main_http_valid_request_returns_200_success():
@@ -172,7 +189,9 @@ def test_main_http_valid_request_returns_200_success():
   ):
     with mock.patch.object(main, 'run') as mock_run:
       response = main.main(flask.request)
-      mock_run.assert_called_once_with('test_sheet_123')
+      mock_run.assert_called_once_with(
+          sheet_id='test_sheet_123', telemetry=mock.ANY
+      )
       assert response.status_code == 200
       data = json.loads(response.get_data(as_text=True))
       assert data['status'] == 'Success'

--- a/src/gads_video_report_fetcher/main.py
+++ b/src/gads_video_report_fetcher/main.py
@@ -33,6 +33,7 @@ from vet_common.events import parse_pubsub_cloudevent
 from vet_common.gads import get_google_ads_client_version
 from vet_common.ids import sanitize_gads_id
 from vet_common.logging import get_service_logger
+from vet_common.logging import PipelineTelemetryContext
 from vet_common.pubsub import publish_batch
 
 logger = get_service_logger()
@@ -385,8 +386,14 @@ def run(
     customer_id: str,
     lookback_days: int,
     gads_filters: str,
+    telemetry: Optional[PipelineTelemetryContext] = None,
 ) -> None:
   """Fetches video placements, upserts today's partition via MERGE, and notifies downstream."""
+  telemetry = telemetry or PipelineTelemetryContext(
+      logger=logger,
+      service_name=os.environ.get('K_SERVICE', 'vet-gads-video-report-fetcher'),
+      customer_id=customer_id,
+  )
   logger.info(
       '[%s] Starting video placement report pipeline (lookback: %d days).',
       customer_id,
@@ -398,9 +405,27 @@ def run(
       gads_filters=gads_filters,
   )
 
+  telemetry.log_step(
+      step='FETCH_GADS_STREAM',
+      records_out=row_count,
+      metadata={
+          'unique_video_ids_count': len(retrieved_video_ids),
+          'lookback_days': lookback_days,
+      },
+  )
+
   if row_count == 0:
     logger.info(
         '[%s] No video placements returned from Google Ads.', customer_id
+    )
+    telemetry.log_step(
+        step='SKIPPED',
+        records_out=0,
+        metadata={
+            'reason': (
+                'No placements returned from Google Ads or account disabled'
+            )
+        },
     )
     return
 
@@ -432,6 +457,17 @@ def run(
       today_date,
   )
 
+  telemetry.log_step(
+      step='CHECK_EXISTING_PARTITION',
+      records_in=len(retrieved_video_ids),
+      records_out=len(new_video_ids),
+      metadata={
+          'partition_date': str(today_date),
+          'existing_ids_count': len(existing_ids),
+          'net_new_ids_count': len(new_video_ids),
+      },
+  )
+
   upsert_ndjson_to_bq(
       client=bq_client,
       ndjson_buffer=buffer,
@@ -442,6 +478,16 @@ def run(
       partition_date=today_date,
       log_prefix=f'[{customer_id}] ',
       logger=logger,
+  )
+
+  telemetry.log_step(
+      step='UPSERT_BIGQUERY',
+      records_in=row_count,
+      records_out=row_count,
+      metadata={
+          'target_table': BIGQUERY_TABLE_NAME,
+          'partition_date': str(today_date),
+      },
   )
 
   if new_video_ids:
@@ -459,6 +505,15 @@ def run(
         YOUTUBE_VIDEO_PUBSUB_TOPIC,
         len(new_video_ids),
     )
+    telemetry.log_step(
+        step='PUBLISH_DOWNSTREAM',
+        records_in=len(new_video_ids),
+        records_out=1,
+        metadata={
+            'topic': YOUTUBE_VIDEO_PUBSUB_TOPIC,
+            'notified': True,
+        },
+    )
   else:
     logger.info(
         '[%s] All %d placements updated in BigQuery via MERGE; no new videos'
@@ -466,6 +521,21 @@ def run(
         customer_id,
         row_count,
     )
+    telemetry.log_step(
+        step='PUBLISH_DOWNSTREAM',
+        records_in=0,
+        records_out=0,
+        metadata={
+            'topic': YOUTUBE_VIDEO_PUBSUB_TOPIC,
+            'notified': False,
+        },
+    )
+
+  telemetry.log_step(
+      step='COMPLETE',
+      records_out=row_count,
+      metadata={'status': 'Success'},
+  )
 
   logger.info('[%s] Completed video placement report pipeline.', customer_id)
 
@@ -485,11 +555,29 @@ def main(cloud_event: functions_framework.cloud_event) -> None:
   lookback_days = int(payload['lookback_days'])
   gads_filters = payload.get('gads_filters', '')
 
+  event_id = (
+      cloud_event.get('id')
+      if hasattr(cloud_event, 'get')
+      else getattr(cloud_event, 'id', None)
+  )
+  telemetry = PipelineTelemetryContext(
+      logger=logger,
+      service_name=os.environ.get('K_SERVICE', 'vet-gads-video-report-fetcher'),
+      customer_id=customer_id,
+      run_id=event_id,
+  )
+  telemetry.log_step(
+      step='INITIALIZE',
+      status='SUCCESS',
+      metadata={'lookback_days': lookback_days, 'gads_filters': gads_filters},
+  )
+
   try:
     run(
         customer_id=customer_id,
         lookback_days=lookback_days,
         gads_filters=gads_filters,
+        telemetry=telemetry,
     )
   except Exception as e:  # pylint: disable=broad-except
     logger.error(
@@ -497,4 +585,10 @@ def main(cloud_event: functions_framework.cloud_event) -> None:
         customer_id,
         e,
         exc_info=True,
+    )
+    telemetry.log_step(
+        step='ERROR',
+        status='FAILED',
+        error=e,
+        metadata={'lookback_days': lookback_days},
     )

--- a/src/gads_video_report_fetcher/requirements.txt
+++ b/src/gads_video_report_fetcher/requirements.txt
@@ -15,7 +15,6 @@
 # - google-cloud-logging
 # - google-cloud-pubsub
 # - google-cloud-bigquery
-# - pandas
-# - db-dtypes
 # - jsonschema
+
 

--- a/src/gads_video_report_fetcher/tests/test_video_report_fetcher_main.py
+++ b/src/gads_video_report_fetcher/tests/test_video_report_fetcher_main.py
@@ -12,8 +12,19 @@ from gads_video_report_fetcher import main
 class MockCloudEvent:
   """Mock CloudEvent object conforming to functions_framework CloudEvent protocol."""
 
-  def __init__(self, data: dict[str, Any]):
+  def __init__(
+      self,
+      data: dict[str, Any],
+      attributes: dict[str, Any] | None = None,
+  ):
     self.data = data
+    self._attributes = attributes or {}
+
+  def get(self, key: str, default: Any = None) -> Any:
+    return self._attributes.get(key, default)
+
+  def __getitem__(self, key: str) -> Any:
+    return self._attributes[key]
 
 
 def test_get_report_query_single_day_without_filters():
@@ -253,10 +264,17 @@ def test_run_new_records_persists_to_bq_and_publishes_event(
   mock_fetch_records.return_value = (fake_buffer, {'v1', 'v2'}, 2)
   mock_get_existing_ids.return_value = {'v1'}
 
-  main.run(customer_id='1234567890', lookback_days=1, gads_filters='')
+  mock_telemetry = mock.Mock()
+  main.run(
+      customer_id='1234567890',
+      lookback_days=1,
+      gads_filters='',
+      telemetry=mock_telemetry,
+  )
 
   mock_upsert_bq.assert_called_once()
   mock_publish_batch.assert_called_once()
+  assert mock_telemetry.log_step.call_count == 5
 
 
 @mock.patch.object(main, 'publish_batch')
@@ -268,10 +286,23 @@ def test_run_empty_report_exits_early_without_bq_or_pubsub(
   """Tests that an empty report stream exits cleanly without writing or publishing."""
   mock_fetch_records.return_value = (io.BytesIO(), set(), 0)
 
-  main.run(customer_id='1234567890', lookback_days=1, gads_filters='')
+  mock_telemetry = mock.Mock()
+  main.run(
+      customer_id='1234567890',
+      lookback_days=1,
+      gads_filters='',
+      telemetry=mock_telemetry,
+  )
 
   mock_upsert_bq.assert_not_called()
   mock_publish_batch.assert_not_called()
+  mock_telemetry.log_step.assert_called_with(
+      step='SKIPPED',
+      records_out=0,
+      metadata={
+          'reason': 'No placements returned from Google Ads or account disabled'
+      },
+  )
 
 
 @mock.patch.object(main, 'run')
@@ -293,6 +324,7 @@ def test_main_cloudevent_valid_payload_executes_run(mock_run):
       customer_id='1234567890',
       lookback_days=7,
       gads_filters='metrics.impressions > 50',
+      telemetry=mock.ANY,
   )
 
 
@@ -330,3 +362,26 @@ def test_main_cloudevent_runtime_exception_handled_gracefully(mock_run):
   # Should catch and log error, avoiding uncaught crash
   main.main(event)
   mock_run.assert_called_once()
+
+
+@mock.patch.object(main, 'run')
+def test_main_cloudevent_extracts_event_id_for_telemetry(mock_run):
+  """Tests that CloudEvent id is extracted via dictionary interface and assigned to telemetry."""
+  payload = {
+      'customer_id': '123-456-7890',
+      'lookback_days': 1,
+      'gads_filters': '',
+  }
+  encoded_data = base64.b64encode(json.dumps(payload).encode('utf-8')).decode(
+      'utf-8'
+  )
+  event = MockCloudEvent(
+      data={'message': {'data': encoded_data}},
+      attributes={'id': 'cloudevent-test-id-12345'},
+  )
+
+  main.main(event)
+
+  mock_run.assert_called_once()
+  telemetry_arg = mock_run.call_args[1]['telemetry']
+  assert telemetry_arg.run_id == 'cloudevent-test-id-12345'

--- a/src/vet_common/bq.py
+++ b/src/vet_common/bq.py
@@ -64,28 +64,6 @@ def write_ndjson_to_bq(
   return output_rows
 
 
-def write_df_to_bq(
-    client: bigquery.Client,
-    df: Any,
-    destination: str,
-    write_disposition: str = 'WRITE_APPEND',
-    schema: Optional[list[bigquery.SchemaField]] = None,
-    logger: Optional[logging.Logger] = None,
-) -> None:
-  """Writes a Pandas DataFrame to BigQuery using a LoadJob (legacy helper)."""
-  log = logger or logging.getLogger(__name__)
-
-  job_config = bigquery.LoadJobConfig(
-      write_disposition=write_disposition,
-  )
-  if schema:
-    job_config.schema = schema
-
-  job = client.load_table_from_dataframe(
-      dataframe=df, destination=destination, job_config=job_config
-  )
-  job.result()
-  log.info('Successfully wrote %d records to %s.', len(df.index), destination)
 
 
 def upsert_ndjson_to_bq(

--- a/src/vet_common/logging.py
+++ b/src/vet_common/logging.py
@@ -14,9 +14,13 @@
 
 """Standardized Cloud Logging bootstrap for Video Exclusion Toolbox services."""
 
+import json
 import logging
 import os
 import sys
+import time
+from typing import Any, Optional
+import uuid
 
 
 def get_service_logger(
@@ -24,11 +28,10 @@ def get_service_logger(
     default_name: str = 'failed_to_get_cloud_function_name',
     log_level: int = logging.INFO,
 ) -> logging.Logger:
-  """Initializes and returns a logger configured for Cloud Run or local testing.
+  """Initializes and returns a clean, non-duplicating service logger for Cloud Run or local testing.
 
-  As a side effect, this function suppresses noisy default logging from
-  third-party client libraries by setting the log level of 'google_genai',
-  'httpx', and 'google.ads.googleads.client' to WARNING.
+  Uses standard stdout streaming which is natively captured by Cloud Run without
+  introducing duplicate handlers or network latency.
 
   Args:
       service_name_env: Environment variable name storing the service name.
@@ -41,18 +44,81 @@ def get_service_logger(
   service_name = os.environ.get(service_name_env, default_name)
   logger = logging.getLogger(service_name)
 
-  if os.getenv('IS_LOCAL_TEST', 'False') == 'True':
-    logging.basicConfig(level=log_level, stream=sys.stdout)
-  else:
-    from google.cloud import logging as cloud_logging  # pylint: disable=g-import-not-at-top
+  # Prevent multiple handlers and duplicate propagation on repeated calls/imports
+  if not logger.handlers:
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(log_level)
+    logger.addHandler(handler)
+    logger.propagate = False
 
-    logging_client = cloud_logging.Client()
-    logging_client.setup_logging(log_level=log_level)
+  logger.setLevel(log_level)
 
   # Suppress noisy default logging from third-party client libraries.
   logging.getLogger('google_genai').setLevel(logging.WARNING)
   logging.getLogger('httpx').setLevel(logging.WARNING)
   logging.getLogger('google.ads.googleads.client').setLevel(logging.WARNING)
 
-  logger.setLevel(log_level)
   return logger
+
+
+class PipelineTelemetryContext:
+  """Manages structured step-by-step execution telemetry for VET services."""
+
+  def __init__(
+      self,
+      logger: logging.Logger,
+      service_name: Optional[str] = None,
+      customer_id: Optional[str] = None,
+      run_id: Optional[str] = None,
+  ):
+    self.logger = logger
+    self.service = service_name or os.environ.get(
+        'K_SERVICE', 'unknown_service'
+    )
+    self.customer_id = customer_id
+    self.run_id = run_id or str(uuid.uuid4())
+    self.start_time = time.perf_counter()
+    self._last_step_time = self.start_time
+
+  def set_customer_id(self, customer_id: Optional[str]) -> None:
+    """Updates the active customer_id context for subsequent steps."""
+    self.customer_id = customer_id
+
+  def log_step(
+      self,
+      step: str,
+      status: str = 'SUCCESS',
+      records_in: int = 0,
+      records_out: int = 0,
+      error: Optional[Exception] = None,
+      metadata: Optional[dict[str, Any]] = None,
+  ) -> dict[str, Any]:
+    """Logs a structured JSON telemetry step to stdout for BigQuery ingestion."""
+    now = time.perf_counter()
+    step_duration_ms = int((now - self._last_step_time) * 1000)
+    elapsed_ms = int((now - self.start_time) * 1000)
+    self._last_step_time = now
+
+    payload = {
+        'event_type': 'pipeline_step',
+        'run_id': self.run_id,
+        'service': self.service,
+        'customer_id': self.customer_id,
+        'step': step,
+        'status': status,
+        'step_duration_ms': step_duration_ms,
+        'elapsed_ms': elapsed_ms,
+        'records_in': records_in,
+        'records_out': records_out,
+        'error_type': type(error).__name__ if error else None,
+        'error_message': str(error) if error else None,
+        'metadata': metadata or {},
+    }
+
+    serialized = json.dumps(payload)
+    if status == 'FAILED':
+      self.logger.error(serialized)
+    else:
+      self.logger.info(serialized)
+
+    return payload

--- a/src/vet_common/tests/test_vet_common.py
+++ b/src/vet_common/tests/test_vet_common.py
@@ -19,17 +19,17 @@ from concurrent import futures
 import datetime
 import io
 import json
+import logging
 import os
+import time
 from typing import Any
 from unittest import mock
 
 from google.cloud import bigquery
 from google.cloud import pubsub_v1
-import pandas as pd
 import pytest
 from vet_common.bq import get_existing_partition_ids
 from vet_common.bq import upsert_ndjson_to_bq
-from vet_common.bq import write_df_to_bq
 from vet_common.bq import write_ndjson_to_bq
 from vet_common.dates import get_lookback_date_range
 from vet_common.events import parse_pubsub_cloudevent
@@ -37,6 +37,7 @@ from vet_common.gads import DEFAULT_GOOGLE_ADS_API_VERSION
 from vet_common.gads import get_google_ads_client_version
 from vet_common.ids import sanitize_gads_id
 from vet_common.logging import get_service_logger
+from vet_common.logging import PipelineTelemetryContext
 from vet_common.pubsub import publish_batch
 
 
@@ -149,17 +150,6 @@ def test_parse_pubsub_cloudevent_empty_or_malformed_returns_none():
   assert parse_pubsub_cloudevent(event_invalid_json) is None
 
 
-def test_write_df_to_bq_executes_load_job():
-  """Test writing dataframe to BigQuery."""
-  mock_client = mock.MagicMock(spec=bigquery.Client)
-  mock_job = mock.MagicMock()
-  mock_client.load_table_from_dataframe.return_value = mock_job
-
-  df = pd.DataFrame([{'a': 1, 'b': 'test'}])
-  write_df_to_bq(mock_client, df, 'proj.dataset.table')
-
-  mock_client.load_table_from_dataframe.assert_called_once()
-  mock_job.result.assert_called_once()
 
 
 def test_write_ndjson_to_bq_executes_load_job():
@@ -250,3 +240,65 @@ def test_get_google_ads_client_version_reads_env_variable():
   """Test that get_google_ads_client_version prioritizes GOOGLE_ADS_CLIENT_VERSION env var."""
   with mock.patch.dict(os.environ, {'GOOGLE_ADS_CLIENT_VERSION': 'v26'}):
     assert get_google_ads_client_version() == 'v26'
+
+
+def test_pipeline_telemetry_context_initialization_and_success_logging():
+  """Test PipelineTelemetryContext logging a structured step."""
+  mock_logger = mock.MagicMock(spec=logging.Logger)
+  telemetry = PipelineTelemetryContext(
+      logger=mock_logger,
+      service_name='test-service',
+      customer_id='1234567890',
+      run_id='run-123',
+  )
+
+  assert telemetry.service == 'test-service'
+  assert telemetry.customer_id == '1234567890'
+  assert telemetry.run_id == 'run-123'
+
+  time.sleep(0.01)
+  payload = telemetry.log_step(
+      step='TEST_STEP',
+      records_in=10,
+      records_out=5,
+      metadata={'extra': 'value'},
+  )
+
+  assert payload['event_type'] == 'pipeline_step'
+  assert payload['run_id'] == 'run-123'
+  assert payload['service'] == 'test-service'
+  assert payload['customer_id'] == '1234567890'
+  assert payload['step'] == 'TEST_STEP'
+  assert payload['status'] == 'SUCCESS'
+  assert payload['records_in'] == 10
+  assert payload['records_out'] == 5
+  assert payload['metadata'] == {'extra': 'value'}
+  assert payload['step_duration_ms'] >= 5
+  assert payload['elapsed_ms'] >= 5
+
+  mock_logger.info.assert_called_once()
+  logged_json = json.loads(mock_logger.info.call_args[0][0])
+  assert logged_json == payload
+
+
+def test_pipeline_telemetry_context_failure_logging():
+  """Test PipelineTelemetryContext logging a failed step."""
+  mock_logger = mock.MagicMock(spec=logging.Logger)
+  telemetry = PipelineTelemetryContext(logger=mock_logger)
+  telemetry.set_customer_id('8056520078')
+
+  err = ValueError('Invalid argument provided')
+  payload = telemetry.log_step(
+      step='FAIL_STEP',
+      status='FAILED',
+      error=err,
+  )
+
+  assert payload['status'] == 'FAILED'
+  assert payload['customer_id'] == '8056520078'
+  assert payload['error_type'] == 'ValueError'
+  assert payload['error_message'] == 'Invalid argument provided'
+
+  mock_logger.error.assert_called_once()
+  logged_json = json.loads(mock_logger.error.call_args[0][0])
+  assert logged_json == payload

--- a/terraform/data_archive_file.tf
+++ b/terraform/data_archive_file.tf
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+locals {
+  vet_common_sources = {
+    for f in fileset("${path.module}/../src/vet_common", "*.py") :
+    "vet_common/${f}" => file("${path.module}/../src/vet_common/${f}")
+  }
+}
+
 data "archive_file" "gads_account_dispatcher" {
   type        = "zip"
   output_path = ".temp/gads_account_dispatcher.zip"
@@ -23,37 +30,12 @@ data "archive_file" "gads_account_dispatcher" {
     content  = "${file("../src/common_requirements.txt")}\n${file("../src/gads_account_dispatcher/requirements.txt")}"
     filename = "requirements.txt"
   }
-  source {
-    content  = file("../src/vet_common/__init__.py")
-    filename = "vet_common/__init__.py"
-  }
-  source {
-    content  = file("../src/vet_common/logging.py")
-    filename = "vet_common/logging.py"
-  }
-  source {
-    content  = file("../src/vet_common/pubsub.py")
-    filename = "vet_common/pubsub.py"
-  }
-  source {
-    content  = file("../src/vet_common/ids.py")
-    filename = "vet_common/ids.py"
-  }
-  source {
-    content  = file("../src/vet_common/events.py")
-    filename = "vet_common/events.py"
-  }
-  source {
-    content  = file("../src/vet_common/dates.py")
-    filename = "vet_common/dates.py"
-  }
-  source {
-    content  = file("../src/vet_common/bq.py")
-    filename = "vet_common/bq.py"
-  }
-  source {
-    content  = file("../src/vet_common/gads.py")
-    filename = "vet_common/gads.py"
+  dynamic "source" {
+    for_each = local.vet_common_sources
+    content {
+      filename = source.key
+      content  = source.value
+    }
   }
   depends_on = [resource.google_project_iam_member.storage_object_admin]
 }
@@ -87,37 +69,12 @@ data "archive_file" "gads_video_report_fetcher" {
     content  = "${file("../src/common_requirements.txt")}\n${file("../src/google_ads_requirements.txt")}\n${file("../src/gads_video_report_fetcher/requirements.txt")}"
     filename = "requirements.txt"
   }
-  source {
-    content  = file("../src/vet_common/__init__.py")
-    filename = "vet_common/__init__.py"
-  }
-  source {
-    content  = file("../src/vet_common/logging.py")
-    filename = "vet_common/logging.py"
-  }
-  source {
-    content  = file("../src/vet_common/pubsub.py")
-    filename = "vet_common/pubsub.py"
-  }
-  source {
-    content  = file("../src/vet_common/ids.py")
-    filename = "vet_common/ids.py"
-  }
-  source {
-    content  = file("../src/vet_common/events.py")
-    filename = "vet_common/events.py"
-  }
-  source {
-    content  = file("../src/vet_common/dates.py")
-    filename = "vet_common/dates.py"
-  }
-  source {
-    content  = file("../src/vet_common/bq.py")
-    filename = "vet_common/bq.py"
-  }
-  source {
-    content  = file("../src/vet_common/gads.py")
-    filename = "vet_common/gads.py"
+  dynamic "source" {
+    for_each = local.vet_common_sources
+    content {
+      filename = source.key
+      content  = source.value
+    }
   }
   depends_on = [resource.google_project_iam_member.storage_object_admin]
 }

--- a/terraform/resource_google_bigquery_dataset_access.tf
+++ b/terraform/resource_google_bigquery_dataset_access.tf
@@ -12,5 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared utilities and common infrastructure for Video Exclusion Toolbox (VET) services."""
-
+resource "google_bigquery_dataset_access" "pipeline_stats_sink_bq_writer" {
+  project       = var.project_id
+  dataset_id    = google_bigquery_dataset.video_exclusion_toolbox.dataset_id
+  role          = "roles/bigquery.dataEditor"
+  user_by_email = replace(google_logging_project_sink.pipeline_stats.writer_identity, "serviceAccount:", "")
+  depends_on    = [google_logging_project_sink.pipeline_stats]
+}

--- a/terraform/resource_google_logging_project_sink.tf
+++ b/terraform/resource_google_logging_project_sink.tf
@@ -1,9 +1,9 @@
 # Copyright 2026 Google LLC
-#
+# 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
+# 
 #     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
@@ -12,5 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared utilities and common infrastructure for Video Exclusion Toolbox (VET) services."""
+resource "google_logging_project_sink" "pipeline_stats" {
+  name        = "vet-pipeline-stats-sink"
+  description = "Routes structured VET pipeline execution telemetry to BigQuery"
+  project     = var.project_id
 
+  destination = "bigquery.googleapis.com/projects/${var.project_id}/datasets/${google_bigquery_dataset.video_exclusion_toolbox.dataset_id}"
+
+  filter = "jsonPayload.event_type=\"pipeline_step\""
+
+  unique_writer_identity = true
+
+  bigquery_options {
+    use_partitioned_tables = true
+  }
+}


### PR DESCRIPTION
# feat(telemetry): implement structured pipeline telemetry, dataset access, and dynamic packaging

## Summary

This PR implements structured, zero-latency execution telemetry across Gen 2 Video Exclusion Toolbox (VET) services, provisions a Google Cloud Logging sink streaming directly to BigQuery, enforces dataset-scoped IAM access control, and optimizes deployment archive packaging and dependencies.

## Key Changes
### 1. Structured Execution Telemetry (`src/vet_common/logging.py`)
* **`PipelineTelemetryContext`:** Added structured execution context tracking step durations (`step_duration_ms`), cumulative runtime (`elapsed_ms`), record throughput (`records_in`, `records_out`), and error metadata.
* **Service Integration:** Integrated telemetry tracking into both `gads_account_dispatcher` and `gads_video_report_fetcher` across all operational steps (`FETCH_CONFIG_SHEET`, `DISPATCH_PUBSUB`, `FETCH_GADS_STREAM`, `CHECK_EXISTING_PARTITION`, `UPSERT_BIGQUERY`).
* **Clean Package Initialization:** Decoupled `src/vet_common/__init__.py` to eliminate eager imports, allowing Python to load only explicitly imported modules into memory at runtime.

### 2. Zero-Latency BigQuery Logging Sink (`terraform/`)
* **Cloud Logging Sink (`resource_google_logging_project_sink.tf`):** Provisioned `vet-pipeline-stats-sink` to intercept all logs matching `jsonPayload.event_type="pipeline_step"` and stream them directly into date-partitioned BigQuery tables (`run_googleapis_com_stdout`) with zero function overhead.
* **Dataset-Scoped Access (`resource_google_bigquery_dataset_access.tf`):** Replaced project-level IAM bindings with dataset-level access control (`roles/bigquery.dataEditor`), adhering to least-privilege principles and operating without requiring project IAM admin rights.

### 3. Dynamic Packaging & Dependency Optimization
* **Automated `vet_common` Packaging (`terraform/data_archive_file.tf`):** Replaced manual file enumerations with `local.vet_common_sources` (`fileset()`) and `dynamic "source"` blocks, making packaging DRY across all services.
* **Streamlined Dependencies (`src/common_requirements.txt`):** Removed redundant `pandas` and `db-dtypes` packages (Gen 2 uses in-flight NDJSON streaming directly into BigQuery LoadJobs).
* **Removed Legacy Helper:** Removed deprecated `write_df_to_bq` from `src/vet_common/bq.py` and aligned unit tests.